### PR TITLE
[REF] show categories without parent_category_id

### DIFF
--- a/website_product_brand/controllers/main.py
+++ b/website_product_brand/controllers/main.py
@@ -43,7 +43,7 @@ class WebsiteSale(website_sale):
             SUPERUSER_ID,
             public_categs,
             context=context)
-        result.qcontext['categories'] = categories
+        # result.qcontext['categories'] = categories
         result.qcontext['brand'] = brand
         return result
 


### PR DESCRIPTION
Related Pr https://github.com/Vauxoo/addons-vauxoo/pull/524

To show all categories without parent_id category
