### PR TITLE
[FIX] website_product_filters: monkeypatch it is not necessary, this was causing an error on others modules that tried to inherit the 'website_sale' class, inheritance mechanism was broken on this model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
 install:
   - git clone https://github.com/vauxoo/maintainer-quality-tools.git -b master ${HOME}/maintainer-quality-tools
-  - git clone https://github.com/OCA/product-attribute.git -b 8.0 ${HOME}/product-attribute
+  - git clone https://github.com/vauxoo/product-attribute.git -b 8.0 ${HOME}/product-attribute
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
 

--- a/website_product_brand/controllers/main.py
+++ b/website_product_brand/controllers/main.py
@@ -51,5 +51,3 @@ class WebsiteSale(website_sale):
         return request.website.render(
             'website_product_brand.product_brands',
             values)
-
-openerp.addons.website_sale.controllers.main.website_sale = WebsiteSale


### PR DESCRIPTION
Build https://github.com/Vauxoo/yoytec/pull/961
Fixes https://github.com/Vauxoo/odoo-apps/issues/15
